### PR TITLE
Add pedalboard test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ After installing [Rust](https://rustup.rs/), you can compile Colourizer Rs as fo
 ```shell
 cargo xtask bundle colourizer_rs --release
 ```
+
+## Testing with Python
+
+You can validate the built VST3 using [Pedalboard](https://github.com/spotify/pedalboard):
+
+```bash
+pip install pedalboard numpy
+python scripts/pedalboard_test.py
+```

--- a/scripts/pedalboard_test.py
+++ b/scripts/pedalboard_test.py
@@ -1,0 +1,19 @@
+import numpy as np
+from pedalboard import Pedalboard, VST3Plugin
+
+
+def main():
+    plugin_path = 'target/bundled/Colourizer Rs.vst3'
+    plugin = VST3Plugin(plugin_path)
+
+    board = Pedalboard([plugin])
+
+    sr = 48000
+    samples = np.random.randn(2, sr).astype(np.float32)
+
+    processed = board(samples, sr)
+    print('Processed audio shape:', processed.shape)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add simple script to validate VST3 plugin with pedalboard
- document Python testing instructions in README

## Testing
- `cargo test`
- `python scripts/pedalboard_test.py`


------
https://chatgpt.com/codex/tasks/task_e_684d658129208327b684a4d32c362448