### PR TITLE
Adjust filter intensity

### DIFF
--- a/docs/peak_filter_memo.md
+++ b/docs/peak_filter_memo.md
@@ -3,7 +3,7 @@
 The original filter bank used a peaking EQ with 0 dB gain which acts as an
 all‑pass filter. By subtracting the dry input from a high‑gain peaking filter we
 obtain a narrow band‐pass response. A high `Q` makes the peak very sharp while a
-large positive gain (40 dB) increases the difference between the centre
+large positive gain (20 dB) increases the difference between the centre
 frequency and its neighbours.
 
 Processing a sample `x[n]` with a peaking filter `H(z)` and subtracting the

--- a/src/filterbank.rs
+++ b/src/filterbank.rs
@@ -83,8 +83,11 @@ impl FilterBank {
         for midi in 12u8..=119u8 {
             let freq = 440.0_f32 * 2.0_f32.powf((midi as f32 - 69.0) / 12.0);
             let idx = midi % 12;
-            // Use a very sharp peak to approximate a band-pass filter.
-            let filter = PeakFilter::new(freq, 300.0, 40.0, sample_rate);
+            // Use a reasonably narrow peak to approximate a band-pass filter.
+            // The original version used Q=300 and 40 dB gain which produced
+            // very sharp peaks and extreme amplification. Here the Q and gain
+            // are reduced to keep the effect more controlled.
+            let filter = PeakFilter::new(freq, 100.0, 20.0, sample_rate);
             filters.push((idx, filter));
         }
 

--- a/tests/test_frequency_response.py
+++ b/tests/test_frequency_response.py
@@ -2,8 +2,8 @@ import numpy as np
 from scipy.signal import lfilter
 
 SR = 44100
-Q = 300.0
-GAIN_DB = 40.0
+Q = 100.0
+GAIN_DB = 20.0
 A = 10 ** (GAIN_DB / 40)
 
 


### PR DESCRIPTION
## Summary
- moderate the Q and gain used for the PeakFilter
- reflect the new parameters in the frequency response test
- update docs to mention the lower default gain

## Testing
- `cargo test --all --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_684d90eba1d88327bab2f357d109552f